### PR TITLE
Potential fix for code scanning alert no. 12: Disallow unused variables

### DIFF
--- a/src/pid-file.ts
+++ b/src/pid-file.ts
@@ -25,7 +25,7 @@ export class PidFile {
     try {
       process.kill(pid, 0);
       return true;
-    } catch (err) { // eslint-disable-line @typescript-eslint/no-unused-vars
+    } catch {
       return false;
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/Jujulego/pid-file/security/code-scanning/12](https://github.com/Jujulego/pid-file/security/code-scanning/12)

To fix the problem, we should remove the unused `err` catch variable from the catch block on line 28 of `src/pid-file.ts`. In TypeScript (and JavaScript since ES2019), catch blocks support omitting the error variable entirely if it is not needed. This change preserves all existing functionality while satisfying linting rules and improving code clarity. We only need to update the block: remove the `err` variable and the inline eslint suppression. No additional imports, methods, or other changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
